### PR TITLE
fuzz: Add seed, easy flag to ease csmith, skip-build flag

### DIFF
--- a/tests/fuzz.py
+++ b/tests/fuzz.py
@@ -269,7 +269,13 @@ if __name__ == "__main__":
     parser.add_argument('--easy', action='store_true', help="Generate more easy code by csmith option")
     parser.add_argument('--seed', type=int, help="Provide seed of fuzz generation", default=-1)
     args = parser.parse_args()
-            "--inline-function-prob", "10",
+
+    if args.print and args.irgen:
+        raise Exception("Choose an option used for fuzzing: '--print' or '--irgen', NOT both")
+    
+    if args.print:
+        fuzz_arg = "-p"
+    elif args.irgen:
         fuzz_arg = "-i"
     else:
         raise Exception("Specify fuzzing argument")

--- a/tests/fuzz.py
+++ b/tests/fuzz.py
@@ -43,7 +43,7 @@ REPLACE_DICT = {
     r"__asm__\s*\([^\)]*\)": "",    # asm extension in linux
     "typedef __builtin_va_list __gnuc_va_list;": "",
     "typedef __gnuc_va_list va_list;": "",
-    r"fabsf\(": "(",
+    r"\(fabsf\(": "((",
     
     # todo: need to consider the case below in the future:
     # avoid compile-time constant expressed as complex expression such as `1 + 1`
@@ -121,7 +121,7 @@ def generate(tests_dir, bin_path, seed=None, easy=False):
             "--max-struct-fields", "3",
         ]
     args = [bin_path] + options
-    
+
     try:
         proc = subprocess.Popen(args, cwd=tests_dir, stdout=subprocess.PIPE)
         (src, err) = proc.communicate()
@@ -261,11 +261,10 @@ def fuzz(tests_dir, fuzz_arg, num_iter, easy=False):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Fuzzing KECC.')
-    parser.add_argument('-n', '--num', type=int, help='The number of tests', default=None)
+    parser.add_argument('-n', '--num', type=int, help='The number of tests')
     parser.add_argument('-p', '--print', action='store_true', help='Fuzzing C AST printer')
     parser.add_argument('-i', '--irgen', action='store_true', help='Fuzzing irgen')
     parser.add_argument('-r', '--reduce', action='store_true', help="Reducing input file")
-    parser.add_argument('--skip-build', action='store_true', help="Skipping cargo build")
     parser.add_argument('--easy', action='store_true', help="Generate more easy code by csmith option")
     parser.add_argument('--seed', type=int, help="Provide seed of fuzz generation", default=-1)
     args = parser.parse_args()
@@ -288,16 +287,13 @@ if __name__ == "__main__":
 
     tests_dir = os.path.abspath(os.path.dirname(__file__))
 
-    if not args.skip_build:
-        print("Building KECC..")
-        try:
-            proc = subprocess.Popen(["cargo", "build", "--release"], cwd=tests_dir)
-            proc.communicate()
-        except subprocess.TimeoutExpired as e:
-            proc.kill()
-            raise e
-    else: 
-        print("Skip building. You should manually build the binary. Please execute `cargo build --release` to build.")
+    print("Building KECC..")
+    try:
+        proc = subprocess.Popen(["cargo", "build", "--release"], cwd=tests_dir)
+        proc.communicate()
+    except subprocess.TimeoutExpired as e:
+        proc.kill()
+        raise e
 
     if args.reduce:
         creduce(tests_dir, fuzz_arg)

--- a/tests/fuzz.py
+++ b/tests/fuzz.py
@@ -119,7 +119,6 @@ def generate(tests_dir, bin_path, seed=None, easy=False):
             "--max-block-depth", "2",
             "--max-block-size", "2",
             "--max-struct-fields", "3",
-            "--inline-function-prob", "10",
         ]
     args = [bin_path] + options
     
@@ -270,13 +269,7 @@ if __name__ == "__main__":
     parser.add_argument('--easy', action='store_true', help="Generate more easy code by csmith option")
     parser.add_argument('--seed', type=int, help="Provide seed of fuzz generation", default=-1)
     args = parser.parse_args()
-
-    if args.print and args.irgen:
-        raise Exception("Choose an option used for fuzzing: '--print' or '--irgen', NOT both")
-    
-    if args.print:
-        fuzz_arg = "-p"
-    elif args.irgen:
+            "--inline-function-prob", "10",
         fuzz_arg = "-i"
     else:
         raise Exception("Specify fuzzing argument")

--- a/tests/reduce-criteria-template.sh
+++ b/tests/reduce-criteria-template.sh
@@ -50,9 +50,9 @@ if
   grep 'comparison between pointer and integer' outa.txt ||\
   ! gcc -O1 test_reduced.c > cc_out1.txt 2>&1 ||\
   ! gcc -O2 test_reduced.c > cc_out2.txt 2>&1 ||\
-  ! cargo run --manifest-path $PROJECT_DIR/Cargo.toml --features=build-bin --release -- --parse test_reduced.c >/dev/null 2>&1)
+  ! $KECC_BIN --parse test_reduced.c >/dev/null 2>&1)
 then
   exit 1
 fi
 
-cargo run --manifest-path $PROJECT_DIR/Cargo.toml --features=build-bin --release --bin fuzz -- $FUZZ_ARG test_reduced.c 2>&1 | grep -q 'assertion failed'
+$FUZZ_BIN $FUZZ_ARG test_reduced.c 2>&1 | grep -q 'assertion failed'


### PR DESCRIPTION
## Add seed feature
Users can feed seed value by `--seed 42`

## Add an `easy` flag to ease csmith.
Users can ease csmith code generation with `--easy`.
The additional flags to csmith are following.
```
--max-block-depth 2
--max-block-size 2
--max-struct-fields 3
```

## ~Add skip-build flag~
Users can skip `cargo build` by giving `--skip-build`. Just for faster debugging.