### PR TITLE
Remove unused phinodes for HW6

### DIFF
--- a/examples/ir3/cond_and_loop.ir
+++ b/examples/ir3/cond_and_loop.ir
@@ -68,14 +68,13 @@ block b14:
 
 block b15:
   %b15:i0:i32 = add %b8:p0:i32 2:i32
-  j b17(%b15:i0:i32, %b15:i0:i32)
+  j b17(%b15:i0:i32)
 
 block b16:
   %b16:i0:i32 = add %b8:p0:i32 1:i32
-  j b17(%b16:i0:i32, %b16:i0:i32)
+  j b17(%b16:i0:i32)
 
 block b17:
   %b17:p0:i32:i
-  %b17:p1:i32:t2
   j b8(%b17:p0:i32, %b14:p0:i32)
 }

--- a/examples/ir4/cond_and_loop.ir
+++ b/examples/ir4/cond_and_loop.ir
@@ -68,14 +68,13 @@ block b14:
 
 block b15:
   %b15:i0:i32 = add %b8:p0:i32 2:i32
-  j b17(%b15:i0:i32, %b15:i0:i32)
+  j b17(%b15:i0:i32)
 
 block b16:
   %b16:i0:i32 = add %b8:p0:i32 1:i32
-  j b17(%b16:i0:i32, %b16:i0:i32)
+  j b17(%b16:i0:i32)
 
 block b17:
   %b17:p0:i32:i
-  %b17:p1:i32:t2
   j b8(%b17:p0:i32, %b14:p0:i32)
 }

--- a/examples/opt/cond_and_loop.ir
+++ b/examples/opt/cond_and_loop.ir
@@ -66,14 +66,13 @@ block b14:
 
 block b15:
   %b15:i0:i32 = add %b8:p0:i32 2:i32
-  j b17(%b15:i0:i32, %b15:i0:i32)
+  j b17(%b15:i0:i32
 
 block b16:
   %b16:i0:i32 = add %b8:p0:i32 1:i32
-  j b17(%b16:i0:i32, %b16:i0:i32)
+  j b17(%b16:i0:i32)
 
 block b17:
   %b17:p0:i32:i
-  %b17:p1:i32:t2
   j b8(%b17:p0:i32, %b14:p0:i32)
 }


### PR DESCRIPTION
As mentioned in https://github.com/kaist-cp/cs420/issues/398 and somewhat in https://github.com/kaist-cp/cs420/issues/305#issuecomment-656134559, the provided dead code elimination test case for `cond_and_loop` does not remove usused phi nodes. This PR fixes this by removing the phinode.

It seems that there were no other such examples, at least according to my implementation.