### PR TITLE
Add fmt to kecc IR and Assembly

### DIFF
--- a/src/asm/write_asm.rs
+++ b/src/asm/write_asm.rs
@@ -76,418 +76,84 @@ impl WriteLine for Block {
 
 impl WriteString for Directive {
     fn write_string(&self) -> String {
-        match self {
-            Self::Align(value) => format!(".align\t{}", value),
-            Self::Globl(label) => format!(".globl\t{}", label.0),
-            Self::Type(symbol, symbol_type) => {
-                format!(".type\t{}, {}", symbol.0, symbol_type.write_string())
-            }
-            Self::Section(section_type) => format!(".section\t{}", section_type.write_string()),
-            Self::Byte(value) => format!(".byte\t{:#x?}", value),
-            Self::Half(value) => format!(".half\t{:#x?}", value),
-            Self::Word(value) => format!(".word\t{:#x?}", value),
-            Self::Quad(value) => format!(".quad\t{:#x?}", value),
-            Self::Zero(bytes) => format!(".zero\t{:#x?}", bytes),
-        }
+        format!("{}", self)
     }
 }
 
 impl WriteString for SectionType {
     fn write_string(&self) -> String {
-        match self {
-            Self::Text => ".text",
-            Self::Data => ".data",
-            Self::Rodata => ".rodata",
-            Self::Bss => ".bss",
-        }
-        .to_string()
+        format!("{}", self)
     }
 }
 
 impl WriteString for SymbolType {
     fn write_string(&self) -> String {
-        match self {
-            Self::Function => "@function",
-            Self::Object => "@object",
-        }
-        .to_string()
+        format!("{}", self)
     }
 }
 
 impl WriteString for Instruction {
     fn write_string(&self) -> String {
-        match self {
-            Self::RType {
-                instr,
-                rd,
-                rs1,
-                rs2,
-            } => {
-                let rounding_mode = if let RType::FcvtFloatToInt { .. } = instr {
-                    ",rtz"
-                } else {
-                    ""
-                }
-                .to_string();
-
-                format!(
-                    "{}\t{},{}{}{}",
-                    instr.write_string(),
-                    rd.write_string(),
-                    rs1.write_string(),
-                    if let Some(rs2) = rs2 {
-                        format!(",{}", rs2.write_string())
-                    } else {
-                        "".to_string()
-                    },
-                    rounding_mode
-                )
-            }
-            Self::IType {
-                instr,
-                rd,
-                rs1,
-                imm,
-            } => {
-                if let IType::Load { .. } = instr {
-                    format!(
-                        "{}\t{},{}({})",
-                        instr.write_string(),
-                        rd.write_string(),
-                        imm.write_string(),
-                        rs1.write_string()
-                    )
-                } else {
-                    format!(
-                        "{}\t{},{},{}",
-                        instr.write_string(),
-                        rd.write_string(),
-                        rs1.write_string(),
-                        imm.write_string(),
-                    )
-                }
-            }
-            Self::SType {
-                instr,
-                rs1,
-                rs2,
-                imm,
-            } => format!(
-                "{}\t{},{}({})",
-                instr.write_string(),
-                rs2.write_string(),
-                imm.write_string(),
-                rs1.write_string()
-            ),
-            Self::BType {
-                instr,
-                rs1,
-                rs2,
-                imm,
-            } => format!(
-                "{}\t{},{}, {}",
-                instr.write_string(),
-                rs1.write_string(),
-                rs2.write_string(),
-                imm.0,
-            ),
-            Self::UType { instr, rd, imm } => format!(
-                "{}\t{}, {}",
-                instr.write_string(),
-                rd.write_string(),
-                imm.write_string(),
-            ),
-            Self::Pseudo(pseudo) => pseudo.write_string(),
-        }
+        format!("{}", self)
     }
 }
 
 impl WriteString for RType {
     fn write_string(&self) -> String {
-        match self {
-            Self::Add(data_size) => format!("add{}", data_size.word().write_string()),
-            Self::Sub(data_size) => format!("sub{}", data_size.word().write_string()),
-            Self::Sll(data_size) => format!("sll{}", data_size.word().write_string()),
-            Self::Srl(data_size) => format!("srl{}", data_size.word().write_string()),
-            Self::Sra(data_size) => format!("sra{}", data_size.word().write_string()),
-            Self::Mul(data_size) => format!("mul{}", data_size.word().write_string()),
-            Self::Div {
-                data_size,
-                is_signed,
-            } => format!(
-                "div{}{}",
-                if *is_signed { "" } else { "u" },
-                data_size.word().write_string()
-            ),
-            Self::Rem {
-                data_size,
-                is_signed,
-            } => format!(
-                "rem{}{}",
-                if *is_signed { "" } else { "u" },
-                data_size.word().write_string()
-            ),
-            Self::Slt { is_signed } => format!("slt{}", if *is_signed { "" } else { "u" }),
-            Self::Xor => "xor".to_string(),
-            Self::Or => "or".to_string(),
-            Self::And => "and".to_string(),
-            Self::Fadd(data_size) => format!("fadd.{}", data_size.write_string()),
-            Self::Fsub(data_size) => format!("fsub.{}", data_size.write_string()),
-            Self::Fmul(data_size) => format!("fmul.{}", data_size.write_string()),
-            Self::Fdiv(data_size) => format!("fdiv.{}", data_size.write_string()),
-            Self::Feq(data_size) => format!("feq.{}", data_size.write_string()),
-            Self::Flt(data_size) => format!("flt.{}", data_size.write_string()),
-            Self::FmvFloatToInt { float_data_size } => {
-                assert!(float_data_size.is_floating_point());
-                format!(
-                    "fmv.x.{}",
-                    if *float_data_size == DataSize::SinglePrecision {
-                        "w"
-                    } else {
-                        "d"
-                    }
-                )
-            }
-            Self::FmvIntToFloat { float_data_size } => {
-                assert!(float_data_size.is_floating_point());
-                format!(
-                    "fmv.{}.x",
-                    if *float_data_size == DataSize::SinglePrecision {
-                        "w"
-                    } else {
-                        "d"
-                    }
-                )
-            }
-            Self::FcvtFloatToInt {
-                float_data_size,
-                int_data_size,
-                is_signed,
-            } => {
-                assert!(float_data_size.is_floating_point());
-                assert!(matches!(int_data_size, DataSize::Word | DataSize::Double));
-                format!(
-                    "fcvt.{}{}.{}",
-                    if matches!(int_data_size, DataSize::Word) {
-                        "w"
-                    } else {
-                        "l"
-                    },
-                    if *is_signed { "" } else { "u" },
-                    float_data_size.write_string()
-                )
-            }
-            Self::FcvtIntToFloat {
-                int_data_size,
-                float_data_size,
-                is_signed,
-            } => {
-                assert!(float_data_size.is_floating_point());
-                assert!(matches!(int_data_size, DataSize::Word | DataSize::Double));
-                format!(
-                    "fcvt.{}.{}{}",
-                    float_data_size.write_string(),
-                    if matches!(int_data_size, DataSize::Word) {
-                        "w"
-                    } else {
-                        "l"
-                    },
-                    if *is_signed { "" } else { "u" }
-                )
-            }
-            Self::FcvtFloatToFloat { from, to } => {
-                assert!(from.is_floating_point());
-                assert!(to.is_floating_point());
-                format!("fcvt.{}.{}", to.write_string(), from.write_string())
-            }
-        }
+        format!("{}", self)
     }
 }
 
 impl WriteString for IType {
     fn write_string(&self) -> String {
-        match self {
-            Self::Load {
-                data_size,
-                is_signed,
-            } => {
-                if data_size.is_integer() {
-                    format!(
-                        "l{}{}",
-                        data_size.write_string(),
-                        if *is_signed { "" } else { "u" }
-                    )
-                } else {
-                    format!(
-                        "fl{}",
-                        if *data_size == DataSize::SinglePrecision {
-                            "w"
-                        } else {
-                            "d"
-                        }
-                    )
-                }
-            }
-            Self::Addi(data_size) => format!("addi{}", data_size.word().write_string()),
-            Self::Xori => "xori".to_string(),
-            Self::Ori => "ori".to_string(),
-            Self::Andi => "andi".to_string(),
-            Self::Slli(data_size) => format!("slli{}", data_size.word().write_string()),
-            Self::Srli(data_size) => format!("srli{}", data_size.word().write_string()),
-            Self::Srai(data_size) => format!("srai{}", data_size.word().write_string()),
-            Self::Slti { is_signed } => format!("slti{}", if *is_signed { "" } else { "u" }),
-        }
+        format!("{}", self)
     }
 }
 
 impl WriteString for SType {
     fn write_string(&self) -> String {
-        match self {
-            Self::Store(data_size) => {
-                if data_size.is_integer() {
-                    format!("s{}", data_size.write_string())
-                } else {
-                    format!(
-                        "fs{}",
-                        if *data_size == DataSize::SinglePrecision {
-                            "w"
-                        } else {
-                            "d"
-                        }
-                    )
-                }
-            }
-        }
+        format!("{}", self)
     }
 }
 
 impl WriteString for BType {
     fn write_string(&self) -> String {
-        match self {
-            Self::Beq => "beq".to_string(),
-            Self::Bne => "bne".to_string(),
-            Self::Blt { is_signed } => format!("blt{}", if *is_signed { "" } else { "u" }),
-            Self::Bge { is_signed } => format!("bge{}", if *is_signed { "" } else { "u" }),
-        }
+        format!("{}", self)
     }
 }
 
 impl WriteString for UType {
     fn write_string(&self) -> String {
-        match self {
-            Self::Lui => "lui".to_string(),
-        }
+        format!("{}", self)
     }
 }
 
 impl WriteString for Pseudo {
     fn write_string(&self) -> String {
-        match self {
-            Self::La { rd, symbol } => format!("la\t{},{}", rd.write_string(), symbol.0),
-            Self::Li { rd, imm } => format!("li\t{},{}", rd.write_string(), *imm as i64),
-            Self::Mv { rd, rs } => format!("mv\t{},{}", rd.write_string(), rs.write_string()),
-            Self::Fmv { data_size, rd, rs } => format!(
-                "fmv.{}\t{},{}",
-                data_size.write_string(),
-                rd.write_string(),
-                rs.write_string()
-            ),
-            Self::Neg { data_size, rd, rs } => format!(
-                "neg{}\t{},{}",
-                data_size.word().write_string(),
-                rd.write_string(),
-                rs.write_string()
-            ),
-            Self::SextW { rs, rd } => {
-                format!("sext.w\t{},{}", rd.write_string(), rs.write_string())
-            }
-            Self::Seqz { rd, rs } => format!("seqz\t{},{}", rd.write_string(), rs.write_string()),
-            Self::Snez { rd, rs } => format!("snez\t{},{}", rd.write_string(), rs.write_string()),
-            Self::Fneg { data_size, rd, rs } => format!(
-                "fneg.{}\t{},{}",
-                data_size.write_string(),
-                rd.write_string(),
-                rs.write_string()
-            ),
-            Self::J { offset } => format!("j\t{}", offset.0),
-            Self::Jr { rs } => format!("jr\t{}", rs.write_string()),
-            Self::Jalr { rs } => format!("jalr\t{}", rs.write_string()),
-            Self::Ret => "ret".to_string(),
-            Self::Call { offset } => format!("call\t{}", offset.0),
-        }
+        format!("{}", self)
     }
 }
 
 impl WriteString for Immediate {
     fn write_string(&self) -> String {
-        match self {
-            Self::Value(value) => format!("{}", *value as i64),
-            Self::Relocation { relocation, symbol } => {
-                format!("{}({})", relocation.write_string(), symbol.0)
-            }
-        }
+        format!("{}", self)
     }
 }
 
 impl WriteString for RelocationFunction {
     fn write_string(&self) -> String {
-        match self {
-            Self::Hi20 => "%hi",
-            Self::Lo12 => "%lo",
-        }
-        .to_string()
+        format!("{}", self)
     }
 }
 
 impl WriteString for DataSize {
     fn write_string(&self) -> String {
-        match self {
-            Self::Byte => "b",
-            Self::Half => "h",
-            Self::Word => "w",
-            Self::Double => "d",
-            Self::SinglePrecision => "s",
-            Self::DoublePrecision => "d",
-        }
-        .to_string()
+        format!("{}", self)
     }
 }
 
 impl WriteString for Register {
     fn write_string(&self) -> String {
-        match self {
-            Self::Zero => "zero".to_string(),
-            Self::Ra => "ra".to_string(),
-            Self::Sp => "sp".to_string(),
-            Self::Gp => "gp".to_string(),
-            Self::Tp => "tp".to_string(),
-            Self::Temp(registr_type, id) => format!(
-                "{}t{}",
-                if *registr_type == RegisterType::FloatingPoint {
-                    "f"
-                } else {
-                    ""
-                },
-                id
-            ),
-            Self::Saved(registr_type, id) => format!(
-                "{}s{}",
-                if *registr_type == RegisterType::FloatingPoint {
-                    "f"
-                } else {
-                    ""
-                },
-                id
-            ),
-            Self::Arg(registr_type, id) => format!(
-                "{}a{}",
-                if *registr_type == RegisterType::FloatingPoint {
-                    "f"
-                } else {
-                    ""
-                },
-                id
-            ),
-        }
+        format!("{}", self)
     }
 }

--- a/src/ir/dtype.rs
+++ b/src/ir/dtype.rs
@@ -1366,21 +1366,17 @@ impl fmt::Display for Dtype {
                 ..
             } => {
                 let fields = if let Some(fields) = fields {
-                    let fields = fields
-                        .iter()
-                        .map(|f| {
-                            format!(
-                                "{}:{}",
-                                if let Some(name) = f.name() {
-                                    name
-                                } else {
-                                    "%anon"
-                                },
-                                f.deref()
-                            )
-                        })
-                        .collect::<Vec<_>>()
-                        .join(", ");
+                    let fields = fields.iter().format_with(", ", |field, f| {
+                        f(&format_args!(
+                            "{}:{}",
+                            if let Some(name) = field.name() {
+                                name
+                            } else {
+                                "%anon"
+                            },
+                            field.deref()
+                        ))
+                    });
                     format!(":<{}>", fields)
                 } else {
                     "".to_string()
@@ -1393,16 +1389,9 @@ impl fmt::Display for Dtype {
                     fields
                 )
             }
-            Self::Function { ret, params } => write!(
-                f,
-                "[ret:{} params:({})]",
-                ret,
-                params
-                    .iter()
-                    .map(|p| p.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ),
+            Self::Function { ret, params } => {
+                write!(f, "[ret:{} params:({})]", ret, params.iter().format(", "))
+            }
             Self::Typedef { name, is_const } => {
                 write!(f, "{}{}", if *is_const { "const " } else { "" }, name)
             }


### PR DESCRIPTION
- Adds the `fmt::Display` trait for missing KECC IR fields and Assembly where reasonable
- Adding this trait is essential for better quick and dirty debugging  by bashing `print`.