### PR TITLE
add unwrap_single_element_compound_stmt function

### DIFF
--- a/src/c/ast_equiv.rs
+++ b/src/c/ast_equiv.rs
@@ -149,9 +149,23 @@ impl IsEquiv for ParameterDeclaration {
     }
 }
 
+fn unwrap_single_element_compound_stmt(stmt: &Statement) -> &Statement {
+    if let Statement::Compound(items) = stmt {
+        if items.len() == 1 {
+            if let BlockItem::Statement(inner_stmt) = &items[0].node {
+                return &inner_stmt.node;
+            }
+        }
+    }
+    stmt
+}
+
 impl IsEquiv for Statement {
     fn is_equiv(&self, other: &Self) -> bool {
-        match (self, other) {
+        match (
+            unwrap_single_element_compound_stmt(self),
+            unwrap_single_element_compound_stmt(other),
+        ) {
             (Self::Labeled(stmt), Self::Labeled(other_stmt)) => {
                 stmt.node.label.is_equiv(&other_stmt.node.label)
                     && stmt.node.statement.is_equiv(&other_stmt.node.statement)


### PR DESCRIPTION
```c
// Code 1
int int_greater_than(int i, unsigned int j) {
    if (i > j)
        return 1;
    else
        return 0;
}
```
```c
// Code 2
int int_greater_than(int i, unsigned int j) {
  if ((i) > (j)) {
    return 1;
  } else {
    return 0;
  }
}
```
In the code above, `return 1`; and `{return 1;}` have the same semantics, but currently, the AST equivalence check fails.

In Code 1, the statement is parsed directly as `Statement::Return`, while in Code 2, the statement is parsed as a `Statement::Compound` with a length of 1.

This PR adds functionality to transform the inner value of a length-1 Statement::Compound when performing AST equivalence checks.