### PR TITLE
Support list initializer for scalar types and fix char literals

### DIFF
--- a/src/ir/interp.rs
+++ b/src/ir/interp.rs
@@ -285,6 +285,24 @@ impl Value {
 
                     Ok(Self::structure(name.clone(), fields))
                 }
+                Dtype::Int { .. } | Dtype::Float { .. } | Dtype::Pointer { .. } => {
+                    // Handle the initialization of scalar types with the
+                    // `type name = { expr };` syntax
+                    // Reference: https://en.cppreference.com/w/c/language/scalar_initialization
+                    // There should only be one item in the list:
+                    if items.len() != 1 {
+                        return Err(());
+                    }
+                    let only_item = &items.first().unwrap().node;
+
+                    // With no designators
+                    if !only_item.designation.is_empty() {
+                        return Err(());
+                    }
+
+                    // Simply handle it as if it was `type name = expr;`
+                    Self::try_from_initializer(&only_item.initializer.node, dtype, structs)
+                }
                 _ => Err(()),
             },
         }


### PR DESCRIPTION
The changes here are untested, as I have implemented them again and differently from my homework code.

I'll try rebasing my homework code on this and see if it still works, but in the mean time I'm making this MR in case you want to test it or implement it differently.


```c
int i = { 10 }; // Should be fixed

int main() {
    return 'a'; // Partially fixed
}
```