### PR TITLE
disable misleading clippy::unnecessary_fold suggestion library-wide

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 //! KECC: KAIST Educational C Compiler.
 
 #![deny(clippy::all)]
+// See https://github.com/rust-lang/rust-clippy/issues/3351 - clippy will recommend using any over
+// fold in some cases where this will actually change the meaning of the operation.
+#![allow(clippy::unnecessary_fold)]
 // #![deny(rustdoc::all)]
 #![deny(warnings)]
 // Tries to deny all rustc allow lints.


### PR DESCRIPTION
See comment for details, this means students no longer have to disable the linter for individual functions.
This is especially helpful because disabling the linter in submission goes against the spirit of the test script enforcing the linter.

Part of https://github.com/kaist-cp/cs420/issues/583