### PR TITLE
interp: Enforce f32 precision loss after calculation

### DIFF
--- a/examples/ir3/f32_result.ir
+++ b/examples/ir3/f32_result.ir
@@ -1,0 +1,21 @@
+var f32 @a = default
+
+fun i32 @main () {
+init:
+  bid: b0
+  allocations:
+    %l0:f32:b
+
+block b0:
+  %b0:i0:unit = store 0.0:f32 %l0:f32*
+  %b0:i1:f32 = typecast 3:i32 to f32
+  %b0:i2:unit = store %b0:i1:f32 @a:f32*
+  %b0:i3:f32 = load @a:f32*
+  %b0:i4:f32 = typecast 31506172:i32 to f32
+  %b0:i5:f32 = add %b0:i3:f32 %b0:i4:f32
+  %b0:i6:unit = store %b0:i5:f32 %l0:f32*
+  %b0:i7:f32 = load %l0:f32*
+  %b0:i8:i32 = typecast %b0:i7:f32 to i32
+  ret %b0:i8:i32
+}
+

--- a/examples/ir4/f32_result.ir
+++ b/examples/ir4/f32_result.ir
@@ -1,0 +1,21 @@
+var f32 @a = default
+
+fun i32 @main () {
+init:
+  bid: b0
+  allocations:
+    %l0:f32:b
+
+block b0:
+  %b0:i0:unit = nop
+  %b0:i1:f32 = typecast 3:i32 to f32
+  %b0:i2:unit = store %b0:i1:f32 @a:f32*
+  %b0:i3:f32 = load @a:f32*
+  %b0:i4:f32 = typecast 31506172:i32 to f32
+  %b0:i5:f32 = add %b0:i3:f32 %b0:i4:f32
+  %b0:i6:unit = nop
+  %b0:i7:unit = nop
+  %b0:i8:i32 = typecast %b0:i5:f32 to i32
+  ret %b0:i8:i32
+}
+

--- a/src/ir/interp.rs
+++ b/src/ir/interp.rs
@@ -598,6 +598,17 @@ mod calculator {
             ),
         };
 
+        // The calculation above was done with f64, even if the type we are working with is
+        // supposed to be f32.
+        // We now need to coerce the type back, to ensure any kind of precision loss is applied as
+        // if we calculated with f32:
+
+        let result = if width == Dtype::SIZE_OF_FLOAT * Dtype::BITS_OF_BYTE {
+            result as f32 as f64
+        } else {
+            result
+        };
+
         Ok(Value::float(result, width))
     }
 


### PR DESCRIPTION
Floats are stored as f64, even if f32.
When a calculation is made with them, the result needs to be truncated.
This isn't a problem that's obvious in any other examples, and in fact I only found this example code by fuzzing end-to-end, which incidentally results in mem2reg promoting the store that would normally cause the conversion to f32.

See also https://baseconvert.com/ieee-754-floating-point for `31506176.0` and `31506175`.

I unfortunately don't seem to have the C code anymore, but it should have been something similar to:

```c
float a;

int main() {
  a = 31506175.0; // or maybe this one was 31506176.0
  return a; // Implicit cast to int happens here
}
```

This can probably not be merged as it is, because adding files to ir3/ir4 might break tests, I'm not sure.